### PR TITLE
Adicionar syntax highlight aos códigos do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,75 @@
 #### <span style="text-align: center">AUTENTIQUE Api v2</span>
 # 🚀 Usage
-<pre>npm i autentique-v2-nodejs</pre>
+```shell
+npm i autentique-v2-nodejs
+```
 
 **Set file .env**
-<pre>
+```shell
 AUTENTIQUE_URL=https://api.autentique.com.br/v2/graphql
 AUTENTIQUE_TOKEN=YOURTOKEN
 AUTENTIQUE_DEV_MODE=true || false
 # IF TRUE, DOCUMENT CREATE IN MODE SANDBOX
-</pre>
+```
 
 **Import library** `import autentique from from 'thiagozampieri\autentique-v2-nodejs`
 
-**Instance** <pre>autentique.token = AUTENTIQUE_TOKEN</pre>
+**Instance** `autentique.token = AUTENTIQUE_TOKEN`
 
 #### 1 - Listar todos os Documentos
-<pre>autentique.document.listAll(page); // if not isset page is equal 1</pre>
+```javascript
+autentique.document.listAll(page); // if not isset page is equal 1
+```
 
 #### 2 - Listar um Documento
-<pre>autentique.document.listById(documentId);</pre>
+```javascript
+autentique.document.listById(documentId);
+```
 
 #### 3 - Criar um Documento
-<pre>attributes = {
-         document: {
-             name: 'NOME DO DOCUMENTO'
-         },
-         signers: [
-            {
-                email: 'EMAIL-QUEM-VAI-ASSINAR@gmail.com',
-                action: 'SIGN',
-                positions: [
-                    {
-                        x: '50', // Posição do Eixo X da ASSINATURA (0 a 100) 
-                        y: '80', // Posição do Eixo Y da ASSINATURA (0 a 100)
-                        z: '1'   // Página da ASSINATURA
-                    },
-                    {
-                        x: '50', // Posição do Eixo X da ASSINATURA (0 a 100)
-                        y: '50', // Posição do Eixo Y da ASSINATURA (0 a 100)
-                        z: '2'   // Página da ASSINATURA
-                    }
-                ]
-            },
-            { 
-                email: 'thiago.zampieri@gmail.com',
-                action: 'SIGN'
-            },
-            { 
-                name: 'thiago zampieri',
-                action: 'SIGN'
-            }
-        ],
-        file: 'https://www.documento.com.br/Arquivo.pdf'
-    };
- 
- autentique.document.create(attributes);
- </pre>
+```javascript
+attributes = {
+    document: {
+        name: 'NOME DO DOCUMENTO'
+    },
+    signers: [
+        {
+            email: 'EMAIL-QUEM-VAI-ASSINAR@gmail.com',
+            action: 'SIGN',
+            positions: [
+                {
+                    x: '50', // Posição do Eixo X da ASSINATURA (0 a 100) 
+                    y: '80', // Posição do Eixo Y da ASSINATURA (0 a 100)
+                    z: '1'   // Página da ASSINATURA
+                },
+                {
+                    x: '50', // Posição do Eixo X da ASSINATURA (0 a 100)
+                    y: '50', // Posição do Eixo Y da ASSINATURA (0 a 100)
+                    z: '2'   // Página da ASSINATURA
+                }
+            ]
+        },
+        { 
+            email: 'thiago.zampieri@gmail.com',
+            action: 'SIGN'
+        },
+        { 
+            name: 'thiago zampieri',
+            action: 'SIGN'
+        }
+    ],
+    file: 'https://www.documento.com.br/Arquivo.pdf'
+};
+
+autentique.document.create(attributes);
+```
 
 #### 4 - Assinar um Documento
-<pre>autentique.document.signById(documentId);</pre>
+```javascript
+autentique.document.signById(documentId);
+```
 
 #### 5 - Deletar um Documento
-<pre>autentique.document.deleteById(documentId);</pre>
+```javascript
+autentique.document.deleteById(documentId);
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ AUTENTIQUE_DEV_MODE=true || false
 
 **Import library** `import autentique from from 'thiagozampieri\autentique-v2-nodejs`
 
-**Instance** `autentique.token = AUTENTIQUE_TOKEN`
+**Instance**
+```javascript
+autentique.token = AUTENTIQUE_TOKEN
+```
 
 #### 1 - Listar todos os Documentos
 ```javascript


### PR DESCRIPTION
Foi adicionado o `syntax highlight` para os desenvolvedores que verem o exemplo do código entenderem mais fácil.

|Antes|Depois|
|-------|----------|
|![Antes](https://user-images.githubusercontent.com/40769960/134516055-f821ba22-c155-4e57-b123-3f65196d6e47.png)|![Depois](https://user-images.githubusercontent.com/40769960/134515974-4a219e8e-9a5a-456c-a1f7-26fb23c3e6d2.png)|

---

Outro adicional é que dessa forma o github permite copiar o código com 1 clique.

![Peek 2021-09-23 10-36](https://user-images.githubusercontent.com/40769960/134516988-1009ff05-a3b4-44f1-a975-a3dae371b8ec.gif)

